### PR TITLE
SO1S-412 backend keras 보일러플레이트 개발된 걸 기반으로 생성요청관련 수정

### DIFF
--- a/src/main/java/io/so1s/backend/domain/kubernetes/service/KubernetesServiceImpl.java
+++ b/src/main/java/io/so1s/backend/domain/kubernetes/service/KubernetesServiceImpl.java
@@ -83,8 +83,8 @@ public class KubernetesServiceImpl implements KubernetesService {
             "--file", modelMetadata.getUrl(),
             "--input", modelMetadata.getInputDtype(),
             "--output", modelMetadata.getOutputDtype(),
-            "--name", modelMetadata.getModel().getName(),
-            "--tag", modelMetadata.getVersion(),
+            "--name", modelName,
+            "--tag", version,
             "--user", "so1s",
             "--password", "vkxmxkdlaj"
         )
@@ -189,7 +189,7 @@ public class KubernetesServiceImpl implements KubernetesService {
     String namespace = "default";
     String deployName = deployment.getName().toLowerCase();
     String modelName = deployment.getModelMetadata().getModel().getName().toLowerCase();
-    String modelVersion = deployment.getModelMetadata().getVersion();
+    String modelVersion = deployment.getModelMetadata().getVersion().toLowerCase();
 
     Map<String, String> labels = new HashMap<>();
     labels.put("app", "inference");


### PR DESCRIPTION
# SO1S-412 backend keras 보일러플레이트 개발된 걸 기반으로 생성요청관련 수정


## Tasks

- [x]  Kubernetes Job Build Image, Command 수정


## Discussion

- 작업 이전에 dev 클러스터 테스트 중 sleuth, zipkin dependency가 들어가기만해도 pod가 에러없이 그냥 꺼져버리는 이상현상이 있어 일단 main 브랜치에서 제거한 후 작업 진행했습니다.
- 또한, logging 중 request가 들어오면 먼저 log를 띄우고 request를 처리했는데 이와같은 방법 사용시 h2 console 이나 multipart 데이터가 request 데이터를 바인딩하는 곳에 제대로 전송되지 않고 null로 전송되는 이슈가 있어 우선 response log를 띄울때 같이 뜨도록 변경했습니다. (아마 byte array를 통해 데이터를 캐시하고 stream을 다시 만들도록 했는데 파일데이터 같은게 제대로 생성이 안되는 것 같음). 하지만 이렇게 로깅할 경우 request 시간이 제대로 뜨지 않기 때문에 추후에 조금 더 찾아보겠습니다.

## Jira

- SO1S-412
