### PR TITLE
SO1S-500 Build job yaml GET API namespace 하드코딩 제거

### DIFF
--- a/src/main/java/io/so1s/backend/domain/kubernetes/service/KubernetesServiceImpl.java
+++ b/src/main/java/io/so1s/backend/domain/kubernetes/service/KubernetesServiceImpl.java
@@ -500,14 +500,13 @@ public class KubernetesServiceImpl implements KubernetesService {
   }
 
   public HasMetadata getJobObject(String name) {
-    List<Job> jobs = client.batch().v1().jobs().inNamespace("default")
+    List<Job> jobs = client.batch().v1().jobs().inNamespace(getNamespace())
         .withLabel("app", "inference-build").list()
         .getItems();
 
     return jobs.stream()
         .filter((item) -> item.getMetadata().getLabels().get("modelName").equals(name))
-        .collect(Collectors.toList())
-        .get(jobs.size() - 1);
+        .findFirst().get();
   }
 
   public boolean createHPA(io.so1s.backend.domain.deployment.entity.Deployment deployment,


### PR DESCRIPTION
# Build job yaml GET API namespace 하드코딩 제거


## Tasks

- [x] KubernetesServiceImpl.getJobObject() 메소드 내 namespace 하드코딩 제거


## Discussion

- default namespace에서 Job을 검색하고 있어, Yaml GET API에서 500 에러가 발생했습니다. 이러한 오류를 해결하기 위해서, getNamespace() 메소드를 연동해 하드코딩을 제거했습니다.


## Jira

- SO1S-500
