### PR TITLE
Deployment 생성시 해당되는 Registry Auth Secret 연동

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -153,3 +153,5 @@ openapi3.json
 
 src/main/resources/application-dev.yaml
 src/main/generated
+
+*.db

--- a/src/main/java/io/so1s/backend/domain/auth/service/UserService.java
+++ b/src/main/java/io/so1s/backend/domain/auth/service/UserService.java
@@ -12,7 +12,7 @@ public interface UserService {
 
   Optional<User> findByUsername(String username);
 
-  Optional<String> getCurrentUsername();
+  String getCurrentUsername();
 
   User getCurrentUser();
 

--- a/src/main/java/io/so1s/backend/domain/auth/service/UserServiceImpl.java
+++ b/src/main/java/io/so1s/backend/domain/auth/service/UserServiceImpl.java
@@ -103,36 +103,24 @@ public class UserServiceImpl implements UserService {
   }
 
   @Override
-  public Optional<String> getCurrentUsername() {
+  public String getCurrentUsername() {
     final Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
 
     if (authentication == null) {
       log.debug("Security Context에 인증 정보가 없습니다.");
-      return Optional.empty();
+      return "default";
     }
 
-    String username = parseUserName(authentication);
-
-    return Optional.ofNullable(username);
+    return parseUserName(authentication);
   }
 
 
   @Override
   public User getCurrentUser() {
-    Optional<String> optionalCurrentUsername = getCurrentUsername();
+    String username = getCurrentUsername();
+    Optional<User> optionalUser = findByUsername(username);
 
-    if (optionalCurrentUsername.isEmpty()) {
-      return null;
-    }
+    return optionalUser.orElse(null);
 
-    String currentUsername = optionalCurrentUsername.get();
-
-    Optional<User> optionalUser = findByUsername(currentUsername);
-
-    if (optionalUser.isEmpty()) {
-      return null;
-    }
-
-    return optionalUser.get();
   }
 }

--- a/src/main/java/io/so1s/backend/domain/deployment/service/DeploymentService.java
+++ b/src/main/java/io/so1s/backend/domain/deployment/service/DeploymentService.java
@@ -8,7 +8,7 @@ import io.so1s.backend.domain.deployment.entity.Deployment;
 import io.so1s.backend.domain.deployment.exception.DeploymentNotFoundException;
 import io.so1s.backend.domain.deployment.exception.DeploymentUpdateFailedException;
 import io.so1s.backend.domain.resource.entity.Resource;
-import io.so1s.backend.domain.test.v1.exception.ABTestExistsException;
+import io.so1s.backend.domain.test.v2.exception.ABNTestExistsException;
 import io.so1s.backend.global.error.exception.NodeResourceExceededException;
 import java.util.List;
 import java.util.Optional;
@@ -20,11 +20,12 @@ public interface DeploymentService {
       throws NodeResourceExceededException;
 
   DeploymentDeleteResponseDto deleteDeployment(Long id)
-      throws DeploymentNotFoundException, ABTestExistsException;
+      throws DeploymentNotFoundException, ABNTestExistsException;
 
   DeploymentResponseDto updateDeployment(DeploymentRequestDto deploymentRequestDto);
 
-  boolean updateInference(Deployment deployment) throws DeploymentUpdateFailedException;
+  boolean updateInference(Deployment deployment)
+      throws DeploymentUpdateFailedException, ABNTestExistsException;
 
   Deployment validateExistDeployment(String name);
 

--- a/src/main/java/io/so1s/backend/domain/kubernetes/service/KubernetesService.java
+++ b/src/main/java/io/so1s/backend/domain/kubernetes/service/KubernetesService.java
@@ -7,8 +7,6 @@ import io.so1s.backend.domain.resource.entity.Resource;
 
 public interface KubernetesService {
 
-  String getNamespace();
-
   HasMetadata getDeploymentObject(String name);
 
   HasMetadata getJobObject(String name);

--- a/src/main/java/io/so1s/backend/domain/kubernetes/service/KubernetesServiceImpl.java
+++ b/src/main/java/io/so1s/backend/domain/kubernetes/service/KubernetesServiceImpl.java
@@ -8,6 +8,7 @@ import io.fabric8.istio.api.networking.v1beta1.VirtualServiceBuilder;
 import io.fabric8.istio.client.IstioClient;
 import io.fabric8.kubernetes.api.model.HasMetadata;
 import io.fabric8.kubernetes.api.model.HostPathVolumeSourceBuilder;
+import io.fabric8.kubernetes.api.model.LocalObjectReference;
 import io.fabric8.kubernetes.api.model.NamespaceBuilder;
 import io.fabric8.kubernetes.api.model.Quantity;
 import io.fabric8.kubernetes.api.model.ResourceQuotaBuilder;
@@ -26,6 +27,7 @@ import io.fabric8.kubernetes.api.model.batch.v1.JobBuilder;
 import io.fabric8.kubernetes.client.KubernetesClient;
 import io.fabric8.kubernetes.client.KubernetesClientException;
 import io.fabric8.kubernetes.client.internal.SerializationUtils;
+import io.so1s.backend.domain.auth.service.UserService;
 import io.so1s.backend.domain.deployment.dto.request.Standard;
 import io.so1s.backend.domain.kubernetes.exception.TooManyBuildRequestException;
 import io.so1s.backend.domain.kubernetes.utils.JobStatusChecker;
@@ -38,7 +40,6 @@ import io.so1s.backend.global.utils.HashGenerator;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import javax.annotation.PostConstruct;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.core.task.TaskRejectedException;
@@ -57,14 +58,9 @@ public class KubernetesServiceImpl implements KubernetesService {
   private final JobStatusChecker jobStatusChecker;
   private final RegistryKubernetesService registryKubernetesService;
   private final NamespaceService namespaceService;
+  private final UserService userService;
   private final TextEncryptor textEncryptor;
 
-  private String namespace = "";
-
-  @PostConstruct
-  private void initData() {
-    namespace = namespaceService.getNamespace();
-  }
 
   public String getWorkloadToYaml(HasMetadata object) {
     try {
@@ -77,6 +73,7 @@ public class KubernetesServiceImpl implements KubernetesService {
   @Override
   @Transactional(readOnly = true)
   public boolean inferenceServerBuild(ModelMetadata modelMetadata) throws InterruptedException {
+    String namespace = namespaceService.getNamespace();
     Model model = modelMetadata.getModel();
     Registry registry = modelMetadata.getRegistry();
 
@@ -225,15 +222,20 @@ public class KubernetesServiceImpl implements KubernetesService {
   @Transactional(readOnly = true)
   public boolean deployInferenceServer(
       io.so1s.backend.domain.deployment.entity.Deployment deployment) {
+    String namespace = namespaceService.getNamespace();
     String deployName = "inference-" + deployment.getName().toLowerCase();
 
     var modelMetadata = deployment.getModelMetadata();
     var registry = modelMetadata.getRegistry();
 
     String registryUrl = registry.getBaseUrl();
+    String registryName = registry.getName();
     String registryUser = registry.getUsername();
     String modelName = modelMetadata.getModel().getName().toLowerCase();
     String modelVersion = modelMetadata.getVersion().toLowerCase();
+
+    createNamespace(userService.getCurrentUsername());
+    registryKubernetesService.deployRegistrySecret(registry);
 
     Map<String, String> labels = new HashMap<>();
     labels.put("app", "inference");
@@ -266,6 +268,7 @@ public class KubernetesServiceImpl implements KubernetesService {
         .withSchedulerName(
             (!deployment.getResource().getGpu().equals("0")) ? "gpu-resource-scheduler"
                 : "default-scheduler")
+        .withImagePullSecrets(new LocalObjectReference(registryName))
         .addNewContainer()
         .withImagePullPolicy("Always")
         .withName(deployName)
@@ -380,6 +383,7 @@ public class KubernetesServiceImpl implements KubernetesService {
   @Override
   public boolean deleteInferenceServer(
       io.so1s.backend.domain.deployment.entity.Deployment deployment) {
+    String namespace = namespaceService.getNamespace();
     String deploymentName = "inference-" + deployment.getName().toLowerCase();
 
     try {
@@ -400,6 +404,7 @@ public class KubernetesServiceImpl implements KubernetesService {
 
 
   public HasMetadata getDeploymentObject(String name) {
+    String namespace = namespaceService.getNamespace();
     List<Deployment> deployments = client.apps().deployments()
         .inNamespace(namespace)
         .withLabel("app", "inference").list()
@@ -410,6 +415,7 @@ public class KubernetesServiceImpl implements KubernetesService {
   }
 
   public HasMetadata getJobObject(String name) {
+    String namespace = namespaceService.getNamespace();
     List<Job> jobs = client.batch().v1().jobs().inNamespace(namespace)
         .withLabel("app", "inference-build").list()
         .getItems();

--- a/src/main/java/io/so1s/backend/domain/kubernetes/service/KubernetesServiceImpl.java
+++ b/src/main/java/io/so1s/backend/domain/kubernetes/service/KubernetesServiceImpl.java
@@ -90,6 +90,8 @@ public class KubernetesServiceImpl implements KubernetesService {
     labels.put("modelName", modelName);
     labels.put("version", version);
 
+    createNamespace(userService.getCurrentUsername());
+
     final Job job = new JobBuilder()
         .withApiVersion("batch/v1")
         .withNewMetadata()

--- a/src/main/java/io/so1s/backend/domain/kubernetes/service/NamespaceService.java
+++ b/src/main/java/io/so1s/backend/domain/kubernetes/service/NamespaceService.java
@@ -1,0 +1,7 @@
+package io.so1s.backend.domain.kubernetes.service;
+
+public interface NamespaceService {
+
+  String getNamespace();
+
+}

--- a/src/main/java/io/so1s/backend/domain/kubernetes/service/NamespaceServiceImpl.java
+++ b/src/main/java/io/so1s/backend/domain/kubernetes/service/NamespaceServiceImpl.java
@@ -1,0 +1,17 @@
+package io.so1s.backend.domain.kubernetes.service;
+
+import io.so1s.backend.domain.auth.service.UserService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class NamespaceServiceImpl implements NamespaceService {
+
+  private final UserService userService;
+
+  public String getNamespace() {
+    return "so1s-" + userService.getCurrentUsername().orElse("default");
+  }
+
+}

--- a/src/main/java/io/so1s/backend/domain/kubernetes/service/NamespaceServiceImpl.java
+++ b/src/main/java/io/so1s/backend/domain/kubernetes/service/NamespaceServiceImpl.java
@@ -11,7 +11,7 @@ public class NamespaceServiceImpl implements NamespaceService {
   private final UserService userService;
 
   public String getNamespace() {
-    return "so1s-" + userService.getCurrentUsername().orElse("default");
+    return "so1s-" + userService.getCurrentUsername();
   }
 
 }

--- a/src/main/java/io/so1s/backend/domain/kubernetes/utils/DeploymentStatusCheckScheduler.java
+++ b/src/main/java/io/so1s/backend/domain/kubernetes/utils/DeploymentStatusCheckScheduler.java
@@ -3,7 +3,6 @@ package io.so1s.backend.domain.kubernetes.utils;
 import io.fabric8.kubernetes.client.KubernetesClient;
 import io.so1s.backend.domain.deployment.entity.Deployment;
 import io.so1s.backend.domain.deployment.repository.DeploymentRepository;
-import io.so1s.backend.domain.kubernetes.service.KubernetesService;
 import io.so1s.backend.domain.kubernetes.service.NamespaceService;
 import io.so1s.backend.global.vo.Status;
 import java.util.List;
@@ -24,7 +23,6 @@ public class DeploymentStatusCheckScheduler {
   private final KubernetesClient client;
   private final DeploymentRepository deploymentRepository;
   private final ApplicationHealthChecker applicationHealthChecker;
-  private final KubernetesService kubernetesService;
   private final NamespaceService namespaceService;
 
   @Autowired
@@ -44,7 +42,8 @@ public class DeploymentStatusCheckScheduler {
 
     for (Deployment deployment : deployments) {
       Optional<io.fabric8.kubernetes.api.model.apps.Deployment> find = k8sDeployments.stream()
-          .parallel().filter(d -> d.getMetadata().getName().equalsIgnoreCase(deployment.getName()))
+          .parallel().filter(d -> d.getMetadata().getName().equalsIgnoreCase(
+              String.format("inference-%s", deployment.getName())))
           .findAny();
       find.ifPresentOrElse(e -> {
         if (e.getStatus().getConditions().stream()

--- a/src/main/java/io/so1s/backend/domain/kubernetes/utils/DeploymentStatusCheckScheduler.java
+++ b/src/main/java/io/so1s/backend/domain/kubernetes/utils/DeploymentStatusCheckScheduler.java
@@ -4,6 +4,7 @@ import io.fabric8.kubernetes.client.KubernetesClient;
 import io.so1s.backend.domain.deployment.entity.Deployment;
 import io.so1s.backend.domain.deployment.repository.DeploymentRepository;
 import io.so1s.backend.domain.kubernetes.service.KubernetesService;
+import io.so1s.backend.domain.kubernetes.service.NamespaceService;
 import io.so1s.backend.global.vo.Status;
 import java.util.List;
 import java.util.Optional;
@@ -24,6 +25,7 @@ public class DeploymentStatusCheckScheduler {
   private final DeploymentRepository deploymentRepository;
   private final ApplicationHealthChecker applicationHealthChecker;
   private final KubernetesService kubernetesService;
+  private final NamespaceService namespaceService;
 
   @Autowired
   @Lazy
@@ -32,10 +34,12 @@ public class DeploymentStatusCheckScheduler {
   @Scheduled(fixedDelay = 1000L * 60)
   public void checkDeploymentStatus() {
     log.info("Scheduled method DeploymentStatusCheckScheduler.checkDeploymentStatus() invoked");
+
+    String namespace = namespaceService.getNamespace();
     List<Deployment> deployments = deploymentRepository.findAll();
 
     List<io.fabric8.kubernetes.api.model.apps.Deployment> k8sDeployments = client.apps()
-        .deployments().inNamespace(kubernetesService.getNamespace()).withLabel("app", "inference")
+        .deployments().inNamespace(namespace).withLabel("app", "inference")
         .list().getItems();
 
     for (Deployment deployment : deployments) {

--- a/src/main/java/io/so1s/backend/domain/model/entity/ModelMetadata.java
+++ b/src/main/java/io/so1s/backend/domain/model/entity/ModelMetadata.java
@@ -24,6 +24,7 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 import org.hibernate.annotations.Fetch;
 import org.hibernate.annotations.FetchMode;
+import org.springframework.transaction.annotation.Transactional;
 
 @Entity
 @Table(name = "model_metadata")
@@ -79,11 +80,13 @@ public class ModelMetadata extends BaseTimeEntity {
   @Fetch(FetchMode.SUBSELECT)
   private List<Deployment> deployments = new ArrayList<>();
 
+  @Transactional
   public void setModel(Model model) {
     this.model = model;
     model.getModelMetadatas().add(this);
   }
 
+  @Transactional
   public void changeStatus(Status status) {
     this.status = status;
   }

--- a/src/main/java/io/so1s/backend/domain/registry/controller/RegistryController.java
+++ b/src/main/java/io/so1s/backend/domain/registry/controller/RegistryController.java
@@ -2,6 +2,7 @@ package io.so1s.backend.domain.registry.controller;
 
 import io.so1s.backend.domain.registry.dto.mapper.RegistryMapper;
 import io.so1s.backend.domain.registry.dto.request.RegistryUploadRequestDto;
+import io.so1s.backend.domain.registry.dto.response.RegistryDeleteResponseDto;
 import io.so1s.backend.domain.registry.dto.response.RegistryFindResponseDto;
 import io.so1s.backend.domain.registry.service.RegistryService;
 import java.util.List;
@@ -10,7 +11,9 @@ import javax.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -33,6 +36,21 @@ public class RegistryController {
 
     return ResponseEntity
         .status(HttpStatus.CREATED)
+        .body(response);
+  }
+
+  @DeleteMapping("/{registry_id}")
+  public ResponseEntity<RegistryDeleteResponseDto> deleteRegistry(
+      @Valid @PathVariable("registry_id") Long id) {
+
+    boolean success = service.deleteRegistryById(id);
+
+    var response = RegistryDeleteResponseDto.builder()
+        .success(success)
+        .message(String.format("레지스트리 삭제에 %s했습니다.", success ? "성공" : "실패"))
+        .build();
+
+    return ResponseEntity.status(success ? HttpStatus.OK : HttpStatus.BAD_REQUEST)
         .body(response);
   }
 

--- a/src/main/java/io/so1s/backend/domain/registry/dto/mapper/RegistryMapper.java
+++ b/src/main/java/io/so1s/backend/domain/registry/dto/mapper/RegistryMapper.java
@@ -12,4 +12,6 @@ public interface RegistryMapper {
 
   String toStringFormat(Registry registry);
 
+  String toJsonEncoded(Registry registry);
+
 }

--- a/src/main/java/io/so1s/backend/domain/registry/dto/mapper/RegistryMapperImpl.java
+++ b/src/main/java/io/so1s/backend/domain/registry/dto/mapper/RegistryMapperImpl.java
@@ -4,7 +4,7 @@ import io.so1s.backend.domain.crypto.service.SecretKeyService;
 import io.so1s.backend.domain.registry.dto.request.RegistryUploadRequestDto;
 import io.so1s.backend.domain.registry.dto.response.RegistryFindResponseDto;
 import io.so1s.backend.domain.registry.entity.Registry;
-import java.util.Base64;
+import io.so1s.backend.global.utils.Base64Mapper;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
 
@@ -46,14 +46,13 @@ public class RegistryMapperImpl implements RegistryMapper {
     String username = registry.getUsername();
     String password = secretKeyService.decode(registry.getPassword());
 
-    String auth = Base64.getEncoder()
-        .encodeToString(String.format("%s:%s", username, password).getBytes());
+    String auth = Base64Mapper.encode(String.format("%s:%s", username, password));
 
-    return String.format(
+    return Base64Mapper.encode(String.format(
         "{\"auths\":{\"%s\":{\"username\":\"%s\",\"password\":\"%s\",\"auth\":\"%s\"}}}",
         baseUrl,
         username,
         password,
-        auth);
+        auth));
   }
 }

--- a/src/main/java/io/so1s/backend/domain/registry/dto/mapper/RegistryMapperImpl.java
+++ b/src/main/java/io/so1s/backend/domain/registry/dto/mapper/RegistryMapperImpl.java
@@ -4,6 +4,7 @@ import io.so1s.backend.domain.crypto.service.SecretKeyService;
 import io.so1s.backend.domain.registry.dto.request.RegistryUploadRequestDto;
 import io.so1s.backend.domain.registry.dto.response.RegistryFindResponseDto;
 import io.so1s.backend.domain.registry.entity.Registry;
+import java.util.Base64;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
 
@@ -37,5 +38,22 @@ public class RegistryMapperImpl implements RegistryMapper {
   public String toStringFormat(Registry registry) {
     return String.format("%s / %s / %s", registry.getName(), registry.getUsername(),
         registry.getBaseUrl());
+  }
+
+  @Override
+  public String toJsonEncoded(Registry registry) {
+    String baseUrl = registry.getBaseUrl();
+    String username = registry.getUsername();
+    String password = secretKeyService.decode(registry.getPassword());
+
+    String auth = Base64.getEncoder()
+        .encodeToString(String.format("%s:%s", username, password).getBytes());
+
+    return String.format(
+        "{\"auths\":{\"%s\":{\"username\":\"%s\",\"password\":\"%s\",\"auth\":\"%s\"}}}",
+        baseUrl,
+        username,
+        password,
+        auth);
   }
 }

--- a/src/main/java/io/so1s/backend/domain/registry/dto/response/RegistryDeleteResponseDto.java
+++ b/src/main/java/io/so1s/backend/domain/registry/dto/response/RegistryDeleteResponseDto.java
@@ -1,0 +1,20 @@
+package io.so1s.backend.domain.registry.dto.response;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class RegistryDeleteResponseDto {
+
+  @Builder.Default
+  private Boolean success = Boolean.TRUE;
+
+  @Builder.Default
+  private String message = "";
+
+}

--- a/src/main/java/io/so1s/backend/domain/registry/service/RegistryKubernetesService.java
+++ b/src/main/java/io/so1s/backend/domain/registry/service/RegistryKubernetesService.java
@@ -4,6 +4,6 @@ import io.so1s.backend.domain.registry.entity.Registry;
 
 public interface RegistryKubernetesService {
 
-  boolean deployRegistrySecret(Registry registry);
+  void deployRegistrySecret(Registry registry);
 
 }

--- a/src/main/java/io/so1s/backend/domain/registry/service/RegistryKubernetesService.java
+++ b/src/main/java/io/so1s/backend/domain/registry/service/RegistryKubernetesService.java
@@ -1,10 +1,9 @@
 package io.so1s.backend.domain.registry.service;
 
-import io.fabric8.kubernetes.api.model.Secret;
-import java.util.Optional;
+import io.so1s.backend.domain.registry.entity.Registry;
 
 public interface RegistryKubernetesService {
 
-  Optional<Secret> getDefaultSecret();
+  boolean deployRegistrySecret(Registry registry);
 
 }

--- a/src/main/java/io/so1s/backend/domain/registry/service/RegistryService.java
+++ b/src/main/java/io/so1s/backend/domain/registry/service/RegistryService.java
@@ -11,6 +11,8 @@ public interface RegistryService {
 
   Registry saveRegistry(RegistryUploadRequestDto requestDto);
 
+  boolean deleteRegistryById(Long id);
+
   Optional<Registry> findRegistryById(Long id);
 
 }

--- a/src/main/java/io/so1s/backend/domain/registry/service/RegistryServiceImpl.java
+++ b/src/main/java/io/so1s/backend/domain/registry/service/RegistryServiceImpl.java
@@ -13,6 +13,7 @@ import org.springframework.stereotype.Service;
 @RequiredArgsConstructor
 public class RegistryServiceImpl implements RegistryService {
 
+  private final RegistryKubernetesService kubernetesService;
   private final RegistryRepository repository;
   private final RegistryMapper mapper;
 
@@ -23,7 +24,12 @@ public class RegistryServiceImpl implements RegistryService {
 
   @Override
   public Registry saveRegistry(RegistryUploadRequestDto requestDto) {
-    return repository.save(mapper.toEntity(requestDto));
+    Registry registry = mapper.toEntity(requestDto);
+
+    kubernetesService.deployRegistrySecret(registry);
+    repository.save(registry);
+
+    return registry;
   }
 
   @Override

--- a/src/main/java/io/so1s/backend/domain/registry/service/RegistryServiceImpl.java
+++ b/src/main/java/io/so1s/backend/domain/registry/service/RegistryServiceImpl.java
@@ -33,6 +33,19 @@ public class RegistryServiceImpl implements RegistryService {
   }
 
   @Override
+  public boolean deleteRegistryById(Long id) {
+    var entity = repository.findById(id);
+
+    if (entity.isEmpty()) {
+      return false;
+    }
+
+    repository.delete(entity.get());
+
+    return true;
+  }
+
+  @Override
   public Optional<Registry> findRegistryById(Long id) {
     return repository.findById(id);
   }

--- a/src/main/java/io/so1s/backend/domain/resource/service/ResourceServiceImpl.java
+++ b/src/main/java/io/so1s/backend/domain/resource/service/ResourceServiceImpl.java
@@ -96,9 +96,8 @@ public class ResourceServiceImpl implements ResourceService {
             .anyMatch(t -> t.getKey().equals("kind") && t.getValue().equals("inference")))
         .collect(Collectors.toList());
 
+    // Terraform으로 구성된 클러스터가 아닌 자체 매니지드 환경
     if (inferenceNodes.size() == 0) {
-      // Terraform으로 구성된 클러스터가 아닌 자체 매니지드 환경
-
       return true;
     }
 

--- a/src/main/java/io/so1s/backend/domain/resource/service/ResourceServiceImpl.java
+++ b/src/main/java/io/so1s/backend/domain/resource/service/ResourceServiceImpl.java
@@ -88,6 +88,12 @@ public class ResourceServiceImpl implements ResourceService {
 
   @Override
   public boolean isDeployable(Resource resource) {
+    var nodes = nodesService.findNodes();
+
+    if (nodes.isEmpty()) {
+      return false;
+    }
+
     ResourceDto desired = resourceMapper.toServiceDto(resource);
 
     var inferenceNodes = nodesService.findNodes()
@@ -97,7 +103,7 @@ public class ResourceServiceImpl implements ResourceService {
         .collect(Collectors.toList());
 
     // Terraform으로 구성된 클러스터가 아닌 자체 매니지드 환경
-    if (inferenceNodes.size() == 0) {
+    if (inferenceNodes.isEmpty()) {
       return true;
     }
 

--- a/src/main/java/io/so1s/backend/domain/test/v1/service/internal/ABTestKubernetesServiceImpl.java
+++ b/src/main/java/io/so1s/backend/domain/test/v1/service/internal/ABTestKubernetesServiceImpl.java
@@ -12,7 +12,6 @@ import io.so1s.backend.domain.kubernetes.service.NamespaceService;
 import io.so1s.backend.domain.test.v1.entity.ABTest;
 import java.util.HashMap;
 import java.util.Map;
-import javax.annotation.PostConstruct;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -26,16 +25,11 @@ public class ABTestKubernetesServiceImpl implements
   private final KubernetesService kubernetesService;
   private final KubernetesClient client;
   private final IstioClient istioClient;
-  private String namespace;
-
-  @PostConstruct
-  private void initData() {
-    namespace = namespaceService.getNamespace();
-  }
 
   @Transactional(readOnly = true)
   @Override
   public boolean deployABTest(ABTest abTest) {
+    String namespace = namespaceService.getNamespace();
     String abTestName = "ab-test-" + abTest.getName().toLowerCase();
 
     String host = abTestName + ".so1s.io"; // TODO: Fix hard-coded root domain
@@ -124,6 +118,7 @@ public class ABTestKubernetesServiceImpl implements
 
   @Override
   public boolean deleteABTest(ABTest abTest) {
+    String namespace = namespaceService.getNamespace();
     String abTestName = "ab-test-" + abTest.getName().toLowerCase();
 
     try {

--- a/src/main/java/io/so1s/backend/domain/test/v1/service/internal/ABTestKubernetesServiceImpl.java
+++ b/src/main/java/io/so1s/backend/domain/test/v1/service/internal/ABTestKubernetesServiceImpl.java
@@ -8,9 +8,11 @@ import io.fabric8.istio.client.IstioClient;
 import io.fabric8.kubernetes.client.KubernetesClient;
 import io.fabric8.kubernetes.client.KubernetesClientException;
 import io.so1s.backend.domain.kubernetes.service.KubernetesService;
+import io.so1s.backend.domain.kubernetes.service.NamespaceService;
 import io.so1s.backend.domain.test.v1.entity.ABTest;
 import java.util.HashMap;
 import java.util.Map;
+import javax.annotation.PostConstruct;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -20,15 +22,20 @@ import org.springframework.transaction.annotation.Transactional;
 public class ABTestKubernetesServiceImpl implements
     ABTestKubernetesService {
 
+  private final NamespaceService namespaceService;
   private final KubernetesService kubernetesService;
   private final KubernetesClient client;
   private final IstioClient istioClient;
+  private String namespace;
+
+  @PostConstruct
+  private void initData() {
+    namespace = namespaceService.getNamespace();
+  }
 
   @Transactional(readOnly = true)
   @Override
   public boolean deployABTest(ABTest abTest) {
-
-    String namespace = kubernetesService.getNamespace();
     String abTestName = "ab-test-" + abTest.getName().toLowerCase();
 
     String host = abTestName + ".so1s.io"; // TODO: Fix hard-coded root domain
@@ -117,7 +124,6 @@ public class ABTestKubernetesServiceImpl implements
 
   @Override
   public boolean deleteABTest(ABTest abTest) {
-    String namespace = kubernetesService.getNamespace();
     String abTestName = "ab-test-" + abTest.getName().toLowerCase();
 
     try {

--- a/src/main/java/io/so1s/backend/domain/test/v2/dto/mapper/ABNTestMapperImpl.java
+++ b/src/main/java/io/so1s/backend/domain/test/v2/dto/mapper/ABNTestMapperImpl.java
@@ -7,6 +7,7 @@ import io.so1s.backend.domain.test.v2.dto.response.ABNTestCreateResponseDto;
 import io.so1s.backend.domain.test.v2.dto.response.ABNTestReadResponseDto;
 import io.so1s.backend.domain.test.v2.entity.ABNTest;
 import io.so1s.backend.domain.test.v2.repository.ABNTestElementRepository;
+import io.so1s.backend.global.utils.ResourceTemplateStringBuilder;
 import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -38,7 +39,7 @@ public class ABNTestMapperImpl implements ABNTestMapper {
     var entity = ABNTest.builder()
         .name(dto.getName())
         .domain(dto.getDomain())
-        .endPoint(String.format("abn-test-%s.%s", dto.getName().toLowerCase(), dto.getDomain()))
+        .endPoint(ResourceTemplateStringBuilder.ABNTestEndpoint(dto))
         .build();
 
     entity.addElements(elements);

--- a/src/main/java/io/so1s/backend/domain/test/v2/repository/ABNTestQueryRepository.java
+++ b/src/main/java/io/so1s/backend/domain/test/v2/repository/ABNTestQueryRepository.java
@@ -1,0 +1,10 @@
+package io.so1s.backend.domain.test.v2.repository;
+
+import io.so1s.backend.domain.test.v2.entity.ABNTest;
+import java.util.List;
+
+public interface ABNTestQueryRepository {
+
+  List<ABNTest> findAllByDeploymentId(Long deploymentId);
+
+}

--- a/src/main/java/io/so1s/backend/domain/test/v2/repository/ABNTestQueryRepositoryImpl.java
+++ b/src/main/java/io/so1s/backend/domain/test/v2/repository/ABNTestQueryRepositoryImpl.java
@@ -1,0 +1,23 @@
+package io.so1s.backend.domain.test.v2.repository;
+
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import io.so1s.backend.domain.test.v2.entity.ABNTest;
+import io.so1s.backend.domain.test.v2.entity.QABNTest;
+import io.so1s.backend.domain.test.v2.entity.QABNTestElement;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+
+@RequiredArgsConstructor
+public class ABNTestQueryRepositoryImpl implements
+    ABNTestQueryRepository {
+
+  private final JPAQueryFactory jpaQueryFactory;
+
+  @Override
+  public List<ABNTest> findAllByDeploymentId(Long deploymentId) {
+    return jpaQueryFactory.selectFrom(QABNTest.aBNTest)
+        .innerJoin(QABNTest.aBNTest.elements, QABNTestElement.aBNTestElement)
+        .where(QABNTestElement.aBNTestElement.deployment.id.eq(deploymentId))
+        .fetch();
+  }
+}

--- a/src/main/java/io/so1s/backend/domain/test/v2/repository/ABNTestRepository.java
+++ b/src/main/java/io/so1s/backend/domain/test/v2/repository/ABNTestRepository.java
@@ -4,7 +4,7 @@ import io.so1s.backend.domain.test.v2.entity.ABNTest;
 import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
 
-public interface ABNTestRepository extends JpaRepository<ABNTest, Long> {
+public interface ABNTestRepository extends JpaRepository<ABNTest, Long>, ABNTestQueryRepository {
 
   Optional<ABNTest> findByName(String name);
 

--- a/src/main/java/io/so1s/backend/domain/test/v2/service/internal/ABNTestKubernetesServiceImpl.java
+++ b/src/main/java/io/so1s/backend/domain/test/v2/service/internal/ABNTestKubernetesServiceImpl.java
@@ -12,7 +12,6 @@ import io.so1s.backend.domain.test.v2.entity.ABNTestElement;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import javax.annotation.PostConstruct;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -24,16 +23,11 @@ public class ABNTestKubernetesServiceImpl implements
 
   private final NamespaceService namespaceService;
   private final IstioClient istioClient;
-  private String namespace;
-
-  @PostConstruct
-  private void initData() {
-    namespace = namespaceService.getNamespace();
-  }
 
   @Transactional
   @Override
   public boolean deployABNTest(ABNTest abnTest) {
+    String namespace = namespaceService.getNamespace();
     String fullName = "abn-test-" + abnTest.getName().toLowerCase();
 
     String endpoint = abnTest.getEndPoint();
@@ -116,6 +110,7 @@ public class ABNTestKubernetesServiceImpl implements
 
   @Override
   public boolean deleteABNTest(ABNTest abTest) {
+    String namespace = namespaceService.getNamespace();
     String abTestName = "abn-test-" + abTest.getName().toLowerCase();
 
     try {

--- a/src/main/java/io/so1s/backend/domain/test/v2/service/internal/ABNTestKubernetesServiceImpl.java
+++ b/src/main/java/io/so1s/backend/domain/test/v2/service/internal/ABNTestKubernetesServiceImpl.java
@@ -5,14 +5,14 @@ import io.fabric8.istio.api.networking.v1beta1.GatewayBuilder;
 import io.fabric8.istio.api.networking.v1beta1.VirtualService;
 import io.fabric8.istio.api.networking.v1beta1.VirtualServiceBuilder;
 import io.fabric8.istio.client.IstioClient;
-import io.fabric8.kubernetes.client.KubernetesClient;
 import io.fabric8.kubernetes.client.KubernetesClientException;
-import io.so1s.backend.domain.kubernetes.service.KubernetesService;
+import io.so1s.backend.domain.kubernetes.service.NamespaceService;
 import io.so1s.backend.domain.test.v2.entity.ABNTest;
 import io.so1s.backend.domain.test.v2.entity.ABNTestElement;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import javax.annotation.PostConstruct;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -22,14 +22,18 @@ import org.springframework.transaction.annotation.Transactional;
 public class ABNTestKubernetesServiceImpl implements
     ABNTestKubernetesService {
 
-  private final KubernetesService kubernetesService;
-  private final KubernetesClient client;
+  private final NamespaceService namespaceService;
   private final IstioClient istioClient;
+  private String namespace;
+
+  @PostConstruct
+  private void initData() {
+    namespace = namespaceService.getNamespace();
+  }
 
   @Transactional
   @Override
   public boolean deployABNTest(ABNTest abnTest) {
-    String namespace = kubernetesService.getNamespace();
     String fullName = "abn-test-" + abnTest.getName().toLowerCase();
 
     String endpoint = abnTest.getEndPoint();
@@ -112,7 +116,6 @@ public class ABNTestKubernetesServiceImpl implements
 
   @Override
   public boolean deleteABNTest(ABNTest abTest) {
-    String namespace = kubernetesService.getNamespace();
     String abTestName = "abn-test-" + abTest.getName().toLowerCase();
 
     try {

--- a/src/main/java/io/so1s/backend/global/error/exception/ErrorCode.java
+++ b/src/main/java/io/so1s/backend/global/error/exception/ErrorCode.java
@@ -16,7 +16,7 @@ public enum ErrorCode {
   METHOD_NOT_ALLOWED(405, "Common003", "Invalid Method"),
   INVALID_TYPE_VALUE(400, "Common004", "Invalid Type Value"),
   HANDLE_ACCESS_DENIED(403, "Common005", "Access is Denied"),
-  INTERNAL_SERVER_ERROR(500, "Common006", "Server Error"),
+  INTERNAL_SERVER_ERROR(500, "Common006", "Internal Server Error"),
   ENTITY_NOT_FOUND(404, "Common007", "Entity Not Found"),
   ENTITY_DUPLICATED(409, "Common008", "Entity Duplicated"),
   ENTITY_EXIST(409, "Common009", "Entity Exist"),

--- a/src/main/java/io/so1s/backend/global/initializer/common/KubernetesInitializer.java
+++ b/src/main/java/io/so1s/backend/global/initializer/common/KubernetesInitializer.java
@@ -2,8 +2,6 @@ package io.so1s.backend.global.initializer.common;
 
 import io.fabric8.kubernetes.client.KubernetesClient;
 import io.fabric8.kubernetes.client.KubernetesClientException;
-import io.so1s.backend.domain.kubernetes.service.KubernetesService;
-import javax.annotation.PostConstruct;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
 
@@ -12,22 +10,13 @@ import org.springframework.stereotype.Component;
 public class KubernetesInitializer {
 
   private final KubernetesClient client;
-  private final KubernetesService kubernetesService;
 
-  @PostConstruct
-  private void createNamespace() {
-    if (checkKuberetesConnection()) {
-      kubernetesService.createNamespace("so1s");
-    }
-  }
-
-  public boolean checkKuberetesConnection() {
+  public boolean checkKubernetesConnection() {
     try {
       client.getVersion();
-      return true;
     } catch (KubernetesClientException e) {
-
+      return false;
     }
-    return false;
+    return true;
   }
 }

--- a/src/main/java/io/so1s/backend/global/utils/Base64Mapper.java
+++ b/src/main/java/io/so1s/backend/global/utils/Base64Mapper.java
@@ -1,7 +1,6 @@
 package io.so1s.backend.global.utils;
 
 import java.nio.charset.StandardCharsets;
-import java.util.Arrays;
 import java.util.Base64;
 
 public class Base64Mapper {

--- a/src/main/java/io/so1s/backend/global/utils/ResourceTemplateStringBuilder.java
+++ b/src/main/java/io/so1s/backend/global/utils/ResourceTemplateStringBuilder.java
@@ -1,0 +1,11 @@
+package io.so1s.backend.global.utils;
+
+import io.so1s.backend.domain.test.v2.dto.request.ABNTestRequestDto;
+
+public class ResourceTemplateStringBuilder {
+
+  public static String ABNTestEndpoint(ABNTestRequestDto requestDto) {
+    return String.format("abn-test-%s.%s", requestDto.getName().toLowerCase(),
+        requestDto.getDomain());
+  }
+}

--- a/src/test/java/io/so1s/backend/unit/kubernetes/utils/DeploymentStatusCheckSchedulerTest.java
+++ b/src/test/java/io/so1s/backend/unit/kubernetes/utils/DeploymentStatusCheckSchedulerTest.java
@@ -122,7 +122,7 @@ public class DeploymentStatusCheckSchedulerTest {
         .build());
 
     String namespace = namespaceService.getNamespace();
-    String deployName = deployment.getName().toLowerCase();
+    String deployName = String.format("inference-%s", deployment.getName().toLowerCase());
     Map<String, String> labels = new HashMap<>();
     labels.put("app", "inference");
     labels.put("name", deployName);

--- a/src/test/java/io/so1s/backend/unit/registry/service/RegistryServiceTest.java
+++ b/src/test/java/io/so1s/backend/unit/registry/service/RegistryServiceTest.java
@@ -27,7 +27,7 @@ public class RegistryServiceTest {
   TextEncryptor textEncryptor;
 
   @Test
-  @DisplayName("RegistryService의 Entity Create, Read 관련 메소드가 제대로 동작한다.")
+  @DisplayName("RegistryService의 Entity Create, Read, Delete 관련 메소드가 제대로 동작한다.")
   public void registryServiceTest() {
     RegistryUploadRequestDto requestDto = RegistryUploadRequestDto.builder()
         .name("default")
@@ -52,6 +52,14 @@ public class RegistryServiceTest {
 
     Assertions.assertThat(foundById).isPresent();
     Assertions.assertThat(foundById.get()).isEqualTo(founds.get(0));
+
+    var deleteResult = registryService.deleteRegistryById(id);
+
+    Assertions.assertThat(deleteResult).isTrue();
+
+    foundById = registryService.findRegistryById(id);
+
+    Assertions.assertThat(foundById).isEmpty();
 
   }
 

--- a/src/test/java/io/so1s/backend/unit/resource/service/ResourceServiceTest.java
+++ b/src/test/java/io/so1s/backend/unit/resource/service/ResourceServiceTest.java
@@ -209,18 +209,6 @@ public class ResourceServiceTest {
       }
 
       @Test
-      @DisplayName("인퍼런스 Taint가 존재하지 않는 노드들만 존재하는 환경에서는 할당을 원하는 리소스를 제공할 수 없다.")
-      void noInferenceNodeTest() throws Exception {
-        List<Node> nodes = List.of(
-            createExampleNode("4", "4Gi", "3", "application")
-        );
-
-        given(nodesService.findNodes()).willReturn(nodes);
-
-        assertThat(resourceService.isDeployable(resource)).isFalse();
-      }
-
-      @Test
       @DisplayName("현재 노드가 할당 가능한 리소스를 초과해서 제공할 수 없다.")
       void resourceExceededTest() throws Exception {
         List<Node> nodes = List.of(

--- a/src/test/java/io/so1s/backend/unit/test/repository/ABNTestQueryRepositoryTest.java
+++ b/src/test/java/io/so1s/backend/unit/test/repository/ABNTestQueryRepositoryTest.java
@@ -1,0 +1,33 @@
+package io.so1s.backend.unit.test.repository;
+
+import io.so1s.backend.domain.test.v2.repository.ABNTestRepository;
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.transaction.annotation.Transactional;
+
+@Transactional
+@ExtendWith(MockitoExtension.class)
+@SpringBootTest
+@ActiveProfiles(profiles = {"test"})
+public class ABNTestQueryRepositoryTest {
+
+  @Autowired
+  private ABNTestRepository repository;
+
+  @Test
+  @DisplayName("ABNTestRepository.findAllByDeploymentId() 테스트")
+  public void entitiesTest() {
+    var tests = repository.findAllByDeploymentId(42L);
+
+    Assertions.assertThat(tests).isEmpty();
+
+  }
+
+
+}


### PR DESCRIPTION
# 로그인 후 추가 정보 입력하지 않았을 시 리다이렉트


## Tasks

- [x] Deployment 생성시 해당되는 Registry Auth Secret 연동,
- [x] isDeployable non-terraform 매니지드 환경에서 작동하도록 수정
- [x] Registry delete API 작성
- [x] Secret 생성 메소드 오류 수정
- [x] checkDeploymentStatus() 태스크 오류 수정
- [x] Deployment 수정, 삭제시 ABN 테스트를 기준으로 가드 핸들링
- [x] 메소드 정의, 구현 일부 리팩터링
- [x] Private Registry 기반 Container Image Pull 작동 확인


## Discussion

## Jira

- SO1S-543
